### PR TITLE
speeds createpo by using multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Each `yumserver_mirror` has the following attributes:
 | repo_description | String           | Description of the Yum repo.                             | N/A               |
 | repo_baseurl     | String           | Base URL of the Yum repo.                                | N/A               |
 | use_repo         | Boolean          | If the repo should be availble for the yumserver to use. | true              |
+| repo_workers     | Integer          | Number of createrepo workers to start up.                | server cpu count  |
 
 To Mirror EPEL for EL7 for example:
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -7,8 +7,8 @@ module YumServer
       shell_out!("reposync -d -c /etc/reposync.conf -r #{repo} -p #{path}")
     end
 
-    def self.createrepo(path)
-      shell_out!("createrepo -C #{path}")
+    def self.createrepo(path, workers=10)
+      shell_out!("createrepo --workers #{workers} -C #{path}")
     end
 
     def self.rsync(options, url, path)

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -7,7 +7,7 @@ module YumServer
       shell_out!("reposync -d -c /etc/reposync.conf -r #{repo} -p #{path}")
     end
 
-    def self.createrepo(path, workers=10)
+    def self.createrepo(path, workers)
       shell_out!("createrepo --workers #{workers} -C #{path}")
     end
 

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -4,7 +4,7 @@ property :repo_name, String, required: true
 property :repo_description, String, required: true
 property :repo_baseurl, String, required: true
 property :use_repo, [TrueClass, FalseClass], required: true, default: true
-property :repo_workers, Integer, required: false, default: 10
+property :repo_workers, Integer, required: false, default: node['cpu']['total']
 
 def real_local_path
   if local_path == NilClass

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -43,7 +43,7 @@ action :create do
   end
   ruby_block 'createrepo' do
     block do
-      YumServer::Helper.createrepo(real_local_path, workers=repo_workers)
+      YumServer::Helper.createrepo(real_local_path, repo_workers)
     end
     action :run
   end

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -4,6 +4,7 @@ property :repo_name, String, required: true
 property :repo_description, String, required: true
 property :repo_baseurl, String, required: true
 property :use_repo, [TrueClass, FalseClass], required: true, default: true
+property :repo_workers, Integer, required: false, default: 10
 
 def real_local_path
   if local_path == NilClass
@@ -42,7 +43,7 @@ action :create do
   end
   ruby_block 'createrepo' do
     block do
-      YumServer::Helper.createrepo(real_local_path)
+      YumServer::Helper.createrepo(real_local_path, workers=repo_workers)
     end
     action :run
   end


### PR DESCRIPTION
The createrepo command can take the argument `workers` and uses multithreading to speed up the processing. This adds a new property to yumserver called `repo_workers` default to a conservative 10.